### PR TITLE
Add support for shape serialization

### DIFF
--- a/libs/JoltC/JoltPhysicsC.cpp
+++ b/libs/JoltC/JoltPhysicsC.cpp
@@ -68,7 +68,9 @@ FN(toJph)(const JPC_Body *in) { assert(in); return reinterpret_cast<const JPH::B
 FN(toJpc)(JPH::Body *in) { assert(in); return reinterpret_cast<JPC_Body *>(in); }
 FN(toJph)(JPC_Body *in) { assert(in); return reinterpret_cast<JPH::Body *>(in); }
 
+FN(toJph)(JPC_PhysicsMaterial *in) { return reinterpret_cast<JPH::PhysicsMaterial *>(in); }
 FN(toJph)(const JPC_PhysicsMaterial *in) { return reinterpret_cast<const JPH::PhysicsMaterial *>(in); }
+FN(toJpc)(JPH::PhysicsMaterial *in) { return reinterpret_cast<JPC_PhysicsMaterial *>(in); }
 FN(toJpc)(const JPH::PhysicsMaterial *in) { return reinterpret_cast<const JPC_PhysicsMaterial *>(in); }
 
 FN(toJph)(const JPC_ShapeSettings *in) {
@@ -231,6 +233,36 @@ FN(toJph)(JPC_ConvexHullShape *in) { assert(in); return reinterpret_cast<JPH::Co
 FN(toJph)(const JPC_ConvexHullShape *in) { assert(in); return reinterpret_cast<const JPH::ConvexHullShape *>(in); }
 FN(toJpc)(JPH::ConvexHullShape *in) { assert(in); return reinterpret_cast<JPC_ConvexHullShape *>(in); }
 FN(toJpc)(const JPH::ConvexHullShape *in) { assert(in); return reinterpret_cast<const JPC_ConvexHullShape *>(in); }
+
+FN(toJph)(JPC_DecoratedShape *in) { assert(in); return reinterpret_cast<JPH::DecoratedShape *>(in); }
+FN(toJph)(const JPC_DecoratedShape *in) { assert(in); return reinterpret_cast<const JPH::DecoratedShape *>(in); }
+FN(toJpc)(JPH::DecoratedShape *in) { assert(in); return reinterpret_cast<JPC_DecoratedShape *>(in); }
+FN(toJpc)(const JPH::DecoratedShape *in) { assert(in); return reinterpret_cast<const JPC_DecoratedShape *>(in); }
+
+FN(toJph)(JPC_RotatedTranslatedShape *in) { assert(in); return reinterpret_cast<JPH::RotatedTranslatedShape *>(in); }
+FN(toJph)(const JPC_RotatedTranslatedShape *in) { assert(in); return reinterpret_cast<const JPH::RotatedTranslatedShape *>(in); }
+FN(toJpc)(JPH::RotatedTranslatedShape *in) { assert(in); return reinterpret_cast<JPC_RotatedTranslatedShape *>(in); }
+FN(toJpc)(const JPH::RotatedTranslatedShape *in) { assert(in); return reinterpret_cast<const JPC_RotatedTranslatedShape *>(in); }
+
+FN(toJph)(JPC_ShapeToIDMap *in) { assert(in); return reinterpret_cast<JPH::Shape::ShapeToIDMap *>(in); }
+FN(toJph)(const JPC_ShapeToIDMap *in) { assert(in); return reinterpret_cast<const JPH::Shape::ShapeToIDMap *>(in); }
+FN(toJpc)(JPH::Shape::ShapeToIDMap *in) { assert(in); return reinterpret_cast<JPC_ShapeToIDMap *>(in); }
+FN(toJpc)(const JPH::Shape::ShapeToIDMap *in) { assert(in); return reinterpret_cast<const JPC_ShapeToIDMap *>(in); }
+
+FN(toJph)(JPC_MaterialToIDMap *in) { assert(in); return reinterpret_cast<JPH::Shape::MaterialToIDMap *>(in); }
+FN(toJph)(const JPC_MaterialToIDMap *in) { assert(in); return reinterpret_cast<const JPH::Shape::MaterialToIDMap *>(in); }
+FN(toJpc)(JPH::Shape::MaterialToIDMap *in) { assert(in); return reinterpret_cast<JPC_MaterialToIDMap *>(in); }
+FN(toJpc)(const JPH::Shape::MaterialToIDMap *in) { assert(in); return reinterpret_cast<const JPC_MaterialToIDMap *>(in); }
+
+FN(toJph)(JPC_IDToShapeMap *in) { assert(in); return reinterpret_cast<JPH::Shape::IDToShapeMap *>(in); }
+FN(toJph)(const JPC_IDToShapeMap *in) { assert(in); return reinterpret_cast<const JPH::Shape::IDToShapeMap *>(in); }
+FN(toJpc)(JPH::Shape::IDToShapeMap *in) { assert(in); return reinterpret_cast<JPC_IDToShapeMap *>(in); }
+FN(toJpc)(const JPH::Shape::IDToShapeMap *in) { assert(in); return reinterpret_cast<const JPC_IDToShapeMap *>(in); }
+
+FN(toJph)(JPC_IDToMaterialMap *in) { assert(in); return reinterpret_cast<JPH::Shape::IDToMaterialMap *>(in); }
+FN(toJph)(const JPC_IDToMaterialMap *in) { assert(in); return reinterpret_cast<const JPH::Shape::IDToMaterialMap *>(in); }
+FN(toJpc)(JPH::Shape::IDToMaterialMap *in) { assert(in); return reinterpret_cast<JPC_IDToMaterialMap *>(in); }
+FN(toJpc)(const JPH::Shape::IDToMaterialMap *in) { assert(in); return reinterpret_cast<const JPC_IDToMaterialMap *>(in); }
 
 FN(toJph)(const JPC_ConstraintSettings *in) {
     ENSURE_TYPE(in, JPH::ConstraintSettings);
@@ -1936,6 +1968,168 @@ JPC_Shape_CastRay(const JPC_Shape *in_shape,
     assert(in_shape && in_ray && in_id_creator && io_hit);
     return toJph(in_shape)->CastRay(*toJph(in_ray), *toJph(in_id_creator), *toJph(io_hit));
 }
+
+JPC_API void
+JPC_Shape_SaveBinaryState(const JPC_Shape *in_shape, void *in_stream_out)
+{
+    assert(in_shape && in_stream_out);
+    return toJph(in_shape)->SaveBinaryState(*static_cast<JPH::StreamOut *>(in_stream_out));
+}
+
+JPC_API void
+JPC_Shape_SaveWithChildren(const JPC_Shape *in_shape, void *in_stream_out, JPC_ShapeToIDMap *io_shape_map, JPC_MaterialToIDMap *io_material_map)
+{
+	assert(in_shape && io_shape_map && io_material_map);
+	return toJph(in_shape)->SaveWithChildren(*static_cast<JPH::StreamOut *>(in_stream_out), *toJph(io_shape_map), *toJph(io_material_map));
+}
+
+JPC_API void
+JPC_Shape_SaveWithChildren_All(const JPC_Shape *in_shape, void *in_stream_out)
+{
+	assert(in_shape);
+	JPH::Shape::ShapeToIDMap tmp_shape_map;
+	JPH::Shape::MaterialToIDMap tmp_material_map;
+	return toJph(in_shape)->SaveWithChildren(*static_cast<JPH::StreamOut *>(in_stream_out), tmp_shape_map, tmp_material_map);
+}
+
+JPC_API JPC_Shape*
+JPC_Shape_sRestoreFromBinaryState(void *in_stream_in)
+{
+	assert(in_stream_in);
+	const JPH::Result result = JPH::Shape::sRestoreFromBinaryState(*static_cast<JPH::StreamIn *>(in_stream_in));
+	if (result.HasError()) return nullptr;
+	JPH::Shape *shape = const_cast<JPH::Shape*>(result.Get().GetPtr());
+	shape->AddRef();
+	return toJpc(shape);
+}
+
+JPC_API JPC_Shape*
+JPC_Shape_sRestoreWithChildren(void *in_stream_in, JPC_IDToShapeMap *io_shape_map, JPC_IDToMaterialMap *io_material_map)
+{
+	assert(in_stream_in && io_shape_map && io_material_map); 
+	const JPH::Result result = JPH::Shape::sRestoreWithChildren(*static_cast<JPH::StreamIn *>(in_stream_in),
+																*toJph(io_shape_map),
+																*toJph(io_material_map));
+
+	if (result.HasError()) return nullptr;
+	JPH::Shape *shape = const_cast<JPH::Shape*>(result.Get().GetPtr());
+	shape->AddRef();
+	return toJpc(shape);
+}
+
+JPC_API JPC_Shape*
+JPC_Shape_sRestoreWithChildren_All(void *in_stream_in)
+{
+	assert(in_stream_in); 
+	JPH::Shape::IDToShapeMap tmp_shape_map;
+	JPH::Shape::IDToMaterialMap tmp_material_map;
+	const JPH::Result result = JPH::Shape::sRestoreWithChildren(*static_cast<JPH::StreamIn *>(in_stream_in),
+																tmp_shape_map,
+																tmp_material_map);
+
+	if (result.HasError()) return nullptr;
+	JPH::Shape *shape = const_cast<JPH::Shape*>(result.Get().GetPtr());
+	shape->AddRef();
+	return toJpc(shape);
+}
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_Shape Serialization Structures
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API JPC_ShapeToIDMap *
+JPC_ShapeToIDMap_Create()
+{
+	return toJpc(new JPH::Shape::ShapeToIDMap());
+}
+
+JPC_API void
+JPC_ShapeToIDMap_Add(JPC_ShapeToIDMap *in_map, const JPC_Shape *const *in_shapes, uint32_t in_num_shapes)
+{
+	assert(in_map);
+	JPH::Shape::ShapeToIDMap& map = *toJph(in_map);
+	for (uint32_t i = 0; i < in_num_shapes; ++i)
+	{
+		uint32_t shape_id = (uint32_t)map.size();
+		map[toJph(in_shapes[i])] = shape_id;
+	}
+}
+
+JPC_API void
+JPC_ShapeToIDMap_Destroy(JPC_ShapeToIDMap *in_map)
+{
+	JPH::Free(toJph(in_map));
+}
+
+JPC_API JPC_MaterialToIDMap *
+JPC_MaterialToIDMap_Create()
+{
+	return toJpc(new JPH::Shape::MaterialToIDMap());
+}
+
+JPC_API void
+JPC_MaterialToIDMap_Add(JPC_MaterialToIDMap *in_map, const JPC_PhysicsMaterial *const *in_materials, uint32_t in_num_materials)
+{
+	assert(in_map);
+	JPH::Shape::MaterialToIDMap& map = *toJph(in_map);
+	for (uint32_t i = 0; i < in_num_materials; ++i)
+	{
+		uint32_t material_id = (uint32_t)map.size();
+		map[toJph(in_materials[i])] = material_id;
+	}
+}
+
+JPC_API void
+JPC_MaterialToIDMap_Destroy(JPC_MaterialToIDMap *in_map)
+{
+	JPH::Free(toJph(in_map));
+}
+
+JPC_API JPC_IDToShapeMap*
+JPC_IDToShapeMap_Create()
+{
+	return toJpc(new JPH::Shape::IDToShapeMap());
+}
+
+JPC_API void
+JPC_IDToShapeMap_Add(JPC_IDToShapeMap *in_map, JPC_Shape *const *in_shapes, uint32_t in_num_shapes)
+{
+	assert(in_map);
+	JPH::Shape::IDToShapeMap& map = *toJph(in_map);
+	for (uint32_t i = 0; i < in_num_shapes; ++i)
+	{
+		map.push_back(toJph(in_shapes[i]));
+	}
+}
+
+JPC_API void
+JPC_IDToShapeMap_Destroy(JPC_ShapeToIDMap *in_map)
+{
+	JPH::Free(toJph(in_map));
+}
+
+JPC_API JPC_IDToMaterialMap*
+JPC_IDToMaterialMap_Create()
+{
+	return toJpc(new JPH::Shape::IDToMaterialMap());
+}
+
+JPC_API void
+JPC_IDToMaterialMap_Add(JPC_IDToMaterialMap *in_map, JPC_PhysicsMaterial *const *in_materials, uint32_t in_num_materials)
+{
+	assert(in_map);
+	JPH::Shape::IDToMaterialMap& map = *toJph(in_map);
+	for (uint32_t i = 0; i < in_num_materials; ++i)
+	{
+		map.push_back(toJph(in_materials[i]));
+	}
+}
+
+JPC_API void
+JPC_IDToMaterialMap_Destroy(JPC_ShapeToIDMap *in_map)
+{
+	JPH::Free(toJph(in_map));
+}
 //--------------------------------------------------------------------------------------------------
 //
 // JPC_BoxShape
@@ -1982,6 +2176,32 @@ JPC_ConvexHullShape_GetFaceVertices(const JPC_ConvexHullShape *in_shape,
                                     uint32_t *out_vertices)
 {
     return toJph(in_shape)->GetFaceVertices(in_face_index, in_max_vertices, out_vertices);
+}
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_DecoratedShape
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API const JPC_Shape*
+JPC_DecoratedShape_GetInnerShape(const JPC_DecoratedShape *in_shape)
+{
+	return toJpc(toJph(in_shape)->GetInnerShape());
+}
+//--------------------------------------------------------------------------------------------------
+//
+// JPC_RotatedTranslatedShape
+//
+//--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_RotatedTranslatedShape_GetRotation(const JPC_RotatedTranslatedShape *in_shape, float out_rotation[4])
+{
+    storeVec4(out_rotation, toJph(in_shape)->GetRotation().GetXYZW());
+}
+//--------------------------------------------------------------------------------------------------
+JPC_API void
+JPC_RotatedTranslatedShape_GetPosition(const JPC_RotatedTranslatedShape *in_shape, float out_position[3])
+{
+    storeVec3(out_position, toJph(in_shape)->GetPosition());
 }
 //--------------------------------------------------------------------------------------------------
 //

--- a/libs/JoltC/JoltPhysicsC_Extensions.cpp
+++ b/libs/JoltC/JoltPhysicsC_Extensions.cpp
@@ -163,6 +163,7 @@ ENSURE_SIZE_ALIGN(JPH::RMat44, JPC_RMatrix)
 
 ENSURE_SIZE_ALIGN(JPH::Shape::SupportingFace, JPC_Shape_SupportingFace)
 ENSURE_SIZE_ALIGN(JPH::CharacterVirtual::ExtendedUpdateSettings, JPC_CharacterVirtual_ExtendedUpdateSettings)
+ENSURE_SIZE_ALIGN(JPH::RMat44, JPC_RMatrix)
 
 //--------------------------------------------------------------------------------------------------
 #define ENSURE_ENUM_EQ(c_const, cpp_enum) static_assert(c_const == static_cast<int>(cpp_enum))

--- a/libs/JoltC/JoltPhysicsC_Tests.c
+++ b/libs/JoltC/JoltPhysicsC_Tests.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 
 //#define PRINT_OUTPUT
 
@@ -855,5 +856,281 @@ JoltCTest_HelloWorld(void)
     JPC_DestroyFactory();
 
     return 1;
+}
+//--------------------------------------------------------------------------------------------------
+// Serialization
+//--------------------------------------------------------------------------------------------------
+typedef struct BufferStreamOutImpl
+{
+    const JPC_StreamOutVTable *vtable;
+	void* buffer;
+	size_t len;
+	bool failed;
+} BufferStreamOutImpl;
+
+static void
+BufferedStreamOutImpl_WriteBytes(void *in_self, const void *in_data, size_t in_num_bytes)
+{
+	BufferStreamOutImpl* self = (BufferStreamOutImpl*)in_self;
+	if (self->failed)
+	{
+		return;
+	}
+
+#ifdef PRINT_OUTPUT
+    fprintf(stderr, "BufferedStreamOutImpl_WriteBytes(%llx, %llu)\n", (size_t)in_data, in_num_bytes);
+#endif
+
+	const size_t start = self->len;
+	self->len += in_num_bytes;
+
+	void* new_buffer = realloc(self->buffer, self->len);
+	if (!new_buffer)
+	{
+		free(self->buffer);
+		self->failed = true;
+	}
+
+	self->buffer = new_buffer;
+	memcpy(self->buffer + start, in_data, in_num_bytes);
+}
+
+static bool
+BufferedStreamOutImpl_IsFailed(const void *in_self)
+{
+	const BufferStreamOutImpl* self = (BufferStreamOutImpl*)in_self;
+#ifdef PRINT_OUTPUT
+    fprintf(stderr, "BufferedStreamOutImpl_IsFailed()\n");
+#endif
+	return self->failed;
+}
+
+static BufferStreamOutImpl
+BufferedStreamOutImpl_Init(void)
+{
+    static const JPC_StreamOutVTable vtable =
+    {
+        .WriteBytes = BufferedStreamOutImpl_WriteBytes,
+        .IsFailed = BufferedStreamOutImpl_IsFailed,
+    };
+    BufferStreamOutImpl impl =
+    {
+        .vtable = &vtable,
+		.buffer = NULL,
+		.len = 0,
+		.failed = false,
+    };
+    return impl;
+}
+
+typedef struct BufferStreamInImpl
+{
+    const JPC_StreamInVTable *vtable;
+	void* buffer;
+	size_t len;
+	size_t next;
+	bool eof;
+} BufferStreamInImpl;
+
+static void
+BufferedStreamInImpl_ReadBytes(void *in_self, void *out_data, size_t in_num_bytes)
+{
+	BufferStreamInImpl* self = (BufferStreamInImpl*)in_self;
+#ifdef PRINT_OUTPUT
+	fprintf(stderr, "BufferedStreamInImpl_ReadBytes(%llx, %llu)\n", (size_t)out_data, in_num_bytes);
+#endif
+	
+	const size_t remaining = self->len - self->next;
+	size_t copy_len = in_num_bytes;
+	if (copy_len > remaining)
+	{
+		self->eof = true;
+		copy_len = remaining;
+	}
+
+	if (copy_len > 0)
+	{
+		memcpy(out_data, self->buffer + self->next, copy_len);
+		self->next += copy_len;
+	}
+}
+
+static bool
+BufferedStreamInImpl_IsEOF(const void *in_self)
+{
+	BufferStreamInImpl* self = (BufferStreamInImpl*)in_self;
+#ifdef PRINT_OUTPUT
+    fprintf(stderr, "BufferedStreamInImpl_IsEOF()\n");
+#endif
+	return self->eof;
+}
+
+static bool
+BufferedStreamInImpl_IsFailed(const void *in_self)
+{
+#ifdef PRINT_OUTPUT
+    fprintf(stderr, "BufferedStreamInImpl_IsFailed()\n");
+#endif
+	return false;
+}
+
+static BufferStreamInImpl
+BufferedStreamInImpl_Init(void)
+{
+    static const JPC_StreamInVTable vtable =
+    {
+        .ReadBytes = BufferedStreamInImpl_ReadBytes,
+        .IsEOF = BufferedStreamInImpl_IsEOF,
+        .IsFailed = BufferedStreamInImpl_IsFailed,
+    };
+    BufferStreamInImpl impl =
+    {
+        .vtable = &vtable,
+		.buffer = NULL,
+		.len = 0,
+		.next = 0,
+    };
+    return impl;
+}
+
+uint32_t
+JoltCTest_Serialization(void)
+{
+	JPC_RegisterDefaultAllocator();
+	JPC_CreateFactory();
+	JPC_RegisterTypes();
+
+	JPC_TempAllocator *temp_allocator = JPC_TempAllocator_Create(10 * 1024 * 1024);
+	const float half_extent[3] = { 1.f, 2.f, 3.f };
+
+	// Single shape
+	{
+		JPC_BoxShapeSettings* box_shape_settings = JPC_BoxShapeSettings_Create(half_extent);
+		JPC_Shape* box_shape = JPC_ShapeSettings_CreateShape((JPC_ShapeSettings*)box_shape_settings);
+
+		BufferStreamOutImpl stream_out = BufferedStreamOutImpl_Init();
+		JPC_Shape_SaveBinaryState(box_shape, &stream_out);
+		assert(!stream_out.failed);
+
+		BufferStreamInImpl stream_in = BufferedStreamInImpl_Init();
+		stream_in.buffer = stream_out.buffer;
+		stream_in.len = stream_out.len;
+
+		JPC_Shape* box_restored = JPC_Shape_sRestoreFromBinaryState(&stream_in);
+		assert(JPC_SHAPE_SUB_TYPE_BOX == JPC_Shape_GetSubType(box_restored));
+
+		float half_extent_restored[3] = { 0, 0, 0 };
+		JPC_BoxShape_GetHalfExtent((JPC_BoxShape*)box_restored, half_extent_restored);
+		assert(memcmp(half_extent, half_extent_restored, 3 * sizeof(float)) == 0);
+
+		free(stream_in.buffer);
+	}
+
+	// Compound shapes (save all)
+	{
+		const float translation[3] = { 4.f, 5.f, 6.f };
+		BufferStreamOutImpl stream_out = BufferedStreamOutImpl_Init();
+
+		{
+			JPC_BoxShapeSettings* box_shape_settings = JPC_BoxShapeSettings_Create(half_extent);
+			JPC_DecoratedShapeSettings* decorated_shape_settings = JPC_RotatedTranslatedShapeSettings_Create(
+				(JPC_ShapeSettings*)box_shape_settings,
+				(float[4]) { 0, 0, 0, 1 },
+				translation);
+
+			JPC_Shape* shape = JPC_ShapeSettings_CreateShape((JPC_ShapeSettings*)decorated_shape_settings);
+			JPC_Shape_SaveWithChildren_All(shape, &stream_out);
+			assert(!stream_out.failed);
+		}
+
+		BufferStreamInImpl stream_in = BufferedStreamInImpl_Init();
+		stream_in.buffer = stream_out.buffer;
+		stream_in.len = stream_out.len;
+
+		{
+			JPC_Shape* shape = JPC_Shape_sRestoreWithChildren_All(&stream_in);
+			assert(JPC_SHAPE_SUB_TYPE_ROTATED_TRANSLATED == JPC_Shape_GetSubType(shape));
+
+			JPC_DecoratedShape* decorated = (JPC_DecoratedShape*)shape;
+			const JPC_Shape* inner = JPC_DecoratedShape_GetInnerShape(decorated);
+			assert(JPC_SHAPE_SUB_TYPE_BOX == JPC_Shape_GetSubType(inner));
+
+			float half_extent_restored[3] = { 0, 0, 0 };
+			JPC_BoxShape_GetHalfExtent((const JPC_BoxShape*)inner, half_extent_restored);
+			assert(memcmp(half_extent, half_extent_restored, 3 * sizeof(float)) == 0);
+
+			float translation_restored[3];
+			JPC_RotatedTranslatedShape_GetPosition((JPC_RotatedTranslatedShape*)shape, translation_restored);
+			assert(memcmp(translation, translation_restored, 3 * sizeof(float)) == 0);
+		}
+
+		free(stream_in.buffer);
+	}
+
+	// Compound shapes
+	{
+		BufferStreamOutImpl stream_out = BufferedStreamOutImpl_Init();
+		const float translation[3] = { 7.f, 8.f, 9.f };
+
+		{
+			JPC_BoxShapeSettings* box_shape_settings = JPC_BoxShapeSettings_Create(half_extent);
+			JPC_DecoratedShapeSettings* decorated_shape_settings = JPC_RotatedTranslatedShapeSettings_Create(
+				(JPC_ShapeSettings*)box_shape_settings,
+				(float[4]) { 0, 0, 0, 1 }, 
+				translation);
+
+			JPC_Shape* shape = JPC_ShapeSettings_CreateShape((JPC_ShapeSettings*)decorated_shape_settings);
+			const JPC_Shape* inner_shape = JPC_DecoratedShape_GetInnerShape((JPC_DecoratedShape*)shape);
+
+			JPC_ShapeToIDMap* shape_to_id = JPC_ShapeToIDMap_Create();
+			JPC_MaterialToIDMap* material_to_id = JPC_MaterialToIDMap_Create();
+			JPC_ShapeToIDMap_Add(shape_to_id, &inner_shape, 1);
+			JPC_Shape_SaveWithChildren(shape, &stream_out, shape_to_id, material_to_id);
+			assert(!stream_out.failed);
+			JPC_ShapeToIDMap_Destroy(shape_to_id);
+			JPC_MaterialToIDMap_Destroy(material_to_id);
+		}
+
+		BufferStreamInImpl stream_in = BufferedStreamInImpl_Init();
+		stream_in.buffer = stream_out.buffer;
+		stream_in.len = stream_out.len;
+
+		{
+			JPC_IDToShapeMap* id_to_shape = JPC_IDToShapeMap_Create();
+			JPC_IDToMaterialMap* id_to_material = JPC_IDToMaterialMap_Create();
+
+			const float half_extent_alt[3] = { 4.f, 5.f, 6.f };
+			JPC_BoxShapeSettings* box_shape_settings = JPC_BoxShapeSettings_Create(half_extent_alt);
+			JPC_Shape* box_shape = JPC_ShapeSettings_CreateShape((JPC_ShapeSettings*)box_shape_settings);
+
+			JPC_IDToShapeMap_Add(id_to_shape, &box_shape, 1);
+			JPC_Shape* shape = JPC_Shape_sRestoreWithChildren(&stream_in, id_to_shape, id_to_material);
+			assert(JPC_SHAPE_SUB_TYPE_ROTATED_TRANSLATED == JPC_Shape_GetSubType(shape));
+
+			JPC_DecoratedShape* decorated = (JPC_DecoratedShape*)shape;
+			const JPC_Shape* inner = JPC_DecoratedShape_GetInnerShape(decorated);
+			assert(JPC_SHAPE_SUB_TYPE_BOX == JPC_Shape_GetSubType(inner));
+
+			float half_extent_restored[3] = { 0, 0, 0 };
+			JPC_BoxShape_GetHalfExtent((const JPC_BoxShape*)inner, half_extent_restored);
+			assert(memcmp(half_extent_alt, half_extent_restored, 3 * sizeof(float)) == 0);
+
+			float translation_restored[3];
+			JPC_RotatedTranslatedShape_GetPosition((JPC_RotatedTranslatedShape*)shape, translation_restored);
+			assert(memcmp(translation, translation_restored, 3 * sizeof(float)) == 0);
+
+			JPC_ShapeToIDMap_Destroy(id_to_shape);
+			JPC_MaterialToIDMap_Destroy(id_to_material);
+		}
+
+		free(stream_in.buffer);
+
+	}
+
+
+	JPC_TempAllocator_Destroy(temp_allocator);
+	JPC_DestroyFactory();
+
+	return 1;
 }
 //--------------------------------------------------------------------------------------------------

--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -91,6 +91,129 @@ pub fn RefTargetHeader(comptime first_field_align: u29) type {
     };
 }
 
+pub const StreamOut = extern struct {
+    __v: *const VTable,
+
+    pub fn Methods(comptime T: type) type {
+        return extern struct {
+            pub inline fn writeBytes(self: *T, data: [*]const u8, num_bytes: usize) u32 {
+                return @as(*StreamOut.VTable, @ptrCast(self.__v))
+                    .writeBytes(@as(*StreamOut, @ptrCast(self)), data, num_bytes);
+            }
+            pub inline fn isFailed(self: *const T) bool {
+                return @as(*const StreamOut.VTable, @ptrCast(self.__v))
+                    .isFailed(@as(*const StreamOut, @ptrCast(self)));
+            }
+        };
+    }
+
+    pub const VTable = extern struct {
+        __header: VTableHeader = .{},
+        writeBytes: *const fn (self: *StreamOut, data: [*]const u8, num_bytes: usize) callconv(.C) void,
+        isFailed: *const fn (self: *StreamOut) callconv(.C) bool,
+    };
+
+    comptime {
+        assert(@sizeOf(VTable) == @sizeOf(c.JPC_StreamOutVTable));
+    }
+};
+
+pub const AnyWriterStreamOut = extern struct {
+    usingnamespace StreamOut.Methods(@This());
+    __v: *const StreamOut.VTable = &vtable,
+    writer: *const std.io.AnyWriter,
+    failed: bool = false,
+
+    const vtable = StreamOut.VTable{
+        .writeBytes = _writeBytes,
+        .isFailed = _isFailed,
+    };
+
+    pub fn init(writer: *const std.io.AnyWriter) AnyWriterStreamOut {
+        return .{ .writer = writer };
+    }
+
+    fn _writeBytes(iself: *StreamOut, data: [*]const u8, num_bytes: usize) callconv(.C) void {
+        const self = @as(*AnyWriterStreamOut, @ptrCast(iself));
+        self.writer.writeAll(data[0..num_bytes]) catch {
+            self.failed = true;
+        };
+    }
+
+    fn _isFailed(iself: *StreamOut) callconv(.C) bool {
+        const self = @as(*AnyWriterStreamOut, @ptrCast(iself));
+        return self.failed;
+    }
+};
+
+pub const StreamIn = extern struct {
+    __v: *const VTable,
+
+    pub fn Methods(comptime T: type) type {
+        return extern struct {
+            pub inline fn readBytes(self: *T, data: [*]u8, num_bytes: usize) u32 {
+                return @as(*StreamIn.VTable, @ptrCast(self.__v))
+                    .readBytes(@as(*StreamIn, @ptrCast(self)), data, num_bytes);
+            }
+            pub inline fn isEOF(self: *const T) bool {
+                return @as(*const StreamIn.VTable, @ptrCast(self.__v))
+                    .isEof(@as(*const StreamIn, @ptrCast(self)));
+            }
+            pub inline fn isFailed(self: *const T) bool {
+                return @as(*const StreamIn.VTable, @ptrCast(self.__v))
+                    .isFailed(@as(*const StreamIn, @ptrCast(self)));
+            }
+        };
+    }
+
+    pub const VTable = extern struct {
+        __header: VTableHeader = .{},
+        readBytes: *const fn (self: *StreamIn, data: [*]u8, num_bytes: usize) callconv(.C) void,
+        isEof: *const fn (self: *StreamIn) callconv(.C) bool,
+        isFailed: *const fn (self: *StreamIn) callconv(.C) bool,
+    };
+
+    comptime {
+        assert(@sizeOf(VTable) == @sizeOf(c.JPC_StreamInVTable));
+    }
+};
+
+pub const AnyReaderStreamIn = extern struct {
+    usingnamespace StreamIn.Methods(@This());
+    __v: *const StreamIn.VTable = &vtable,
+    reader: *const std.io.AnyReader,
+    failed: bool = false,
+    eof: bool = false,
+
+    const vtable = StreamIn.VTable{
+        .readBytes = _readBytes,
+        .isEof = _isEof,
+        .isFailed = _isFailed,
+    };
+
+    pub fn init(reader: *const std.io.AnyReader) AnyReaderStreamIn {
+        return .{ .reader = reader };
+    }
+
+    fn _readBytes(iself: *StreamIn, data: [*]u8, num_bytes: usize) callconv(.C) void {
+        const self = @as(*AnyReaderStreamIn, @ptrCast(iself));
+        self.reader.readNoEof(data[0..num_bytes]) catch |err| switch (err) {
+            error.EndOfStream => self.eof = true,
+            else => self.failed = true,
+        };
+    }
+
+    fn _isEof(iself: *StreamIn) callconv(.C) bool {
+        const self = @as(*AnyReaderStreamIn, @ptrCast(iself));
+        return self.eof;
+    }
+
+    fn _isFailed(iself: *StreamIn) callconv(.C) bool {
+        const self = @as(*AnyReaderStreamIn, @ptrCast(iself));
+        return self.failed;
+    }
+};
+
 pub const BroadPhaseLayerInterface = extern struct {
     __v: *const VTable,
 
@@ -3433,6 +3556,20 @@ pub const Shape = opaque {
         }
     };
 
+    pub fn restoreFromBinaryState(stream_in: *StreamIn) !*Shape {
+        const shape = c.JPC_Shape_sRestoreFromBinaryState(stream_in);
+        if (shape == null)
+            return error.FailedToRestoreShape;
+        return @as(*Shape, @ptrCast(shape));
+    }
+
+    pub fn restoreWithChildrenAll(stream_in: *StreamIn) !*Shape {
+        const shape = c.JPC_Shape_sRestoreWithChildren_All(stream_in);
+        if (shape == null)
+            return error.FailedToRestoreShape;
+        return @as(*Shape, @ptrCast(shape));
+    }
+
     fn Methods(comptime T: type) type {
         return struct {
             pub fn asShape(shape: *const T) *const Shape {
@@ -3530,6 +3667,14 @@ pub const Shape = opaque {
                     @as(*c.JPC_RayCastResult, @ptrCast(&hit)),
                 );
                 return .{ .has_hit = has_hit, .hit = hit };
+            }
+
+            pub fn saveBinaryState(shape: *const T, stream_out: *StreamOut) void {
+                c.JPC_Shape_SaveBinaryState(@as(*const c.JPC_Shape, @ptrCast(shape)), stream_out);
+            }
+
+            pub fn saveWithChildrenAll(shape: *const T, stream_out: *StreamOut) void {
+                c.JPC_Shape_SaveWithChildren_All(@as(*const c.JPC_Shape, @ptrCast(shape)), stream_out);
             }
         };
     }
@@ -3893,6 +4038,12 @@ test "jolt_c.basic2" {
 extern fn JoltCTest_HelloWorld() u32;
 test "jolt_c.helloworld" {
     const ret = JoltCTest_HelloWorld();
+    try expect(ret != 0);
+}
+
+extern fn JoltCTest_Serialization() u32;
+test "jolt_c.serialization" {
+    const ret = JoltCTest_Serialization();
     try expect(ret != 0);
 }
 
@@ -4666,6 +4817,42 @@ test "zphysics.debugrenderer" {
     defer DebugRenderer.destroyBodyDrawFilter(draw_filter);
 
     physics_system.drawBodies(&draw_settings, draw_filter);
+}
+
+test "zphysics.serialization" {
+    try init(std.testing.allocator, .{});
+    defer deinit();
+
+    const half_extents: [3]f32 = .{ 1.0, 2.0, 3.0 };
+    const shape_settings = try BoxShapeSettings.create(half_extents);
+    defer shape_settings.release();
+
+    const shape = try shape_settings.createShape();
+    defer shape.release();
+
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(std.testing.allocator);
+
+    {
+        const writer = buf.writer(std.testing.allocator).any();
+        var stream_out = AnyWriterStreamOut.init(&writer);
+        shape.saveBinaryState(@ptrCast(&stream_out));
+        try std.testing.expectEqual(1 + 8 + 4 + 12 + 4, buf.items.len);
+    }
+
+    {
+        var stream = std.io.fixedBufferStream(buf.items);
+        const reader = stream.reader().any();
+        var stream_in = AnyReaderStreamIn.init(&reader);
+        const shape_restored = try Shape.restoreFromBinaryState(@ptrCast(&stream_in));
+        defer shape_restored.release();
+
+        try std.testing.expectEqual(Shape.SubType.box, shape_restored.getSubType());
+
+        const box_shape_restored = BoxShape.asBoxShape(shape_restored);
+        const half_extent_restored = box_shape_restored.getHalfExtent();
+        try std.testing.expectEqual(half_extents, half_extent_restored);
+    }
 }
 
 test {


### PR DESCRIPTION
- Add StreamOut and StreamIn interfaces
- Add implementations of StreamOut / StreamIn that use AnyWriter / AnyReader
- Add Shape::saveBinaryState and Shape::restoreFromBinaryState
- Add Shape::saveWithChildren and Shape::restoreWithChildren
- Add convenience versions saveWithChildrenAll and restoreWithChildrenAll

Continued from https://github.com/zig-gamedev/zig-gamedev/pull/731, now with sub-shape support!