### PR TITLE
Add build option to disable C++ exceptions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,11 @@ pub fn build(b: *std.Build) void {
             "shared",
             "Build JoltC as shared lib",
         ) orelse false,
+        .no_exceptions = b.option(
+            bool,
+            "no_exceptions",
+            "Disable C++ Exceptions",
+        ) orelse false,
     };
 
     const options_step = b.addOptions();
@@ -80,6 +85,7 @@ pub fn build(b: *std.Build) void {
         if (options.enable_debug_renderer) "-DJPH_DEBUG_RENDERER" else "",
         if (options.use_double_precision) "-DJPH_DOUBLE_PRECISION" else "",
         if (options.enable_asserts) "-DJPH_ENABLE_ASSERTS" else "",
+        if (options.no_exceptions) "-fno-exceptions" else "",
         "-fno-access-control",
         "-fno-sanitize=undefined",
     };


### PR DESCRIPTION
I was able to get zphysics building together with zgpu on Windows again by disabling C++ exceptions.

If we can merge this, we might be able to turn on those two samples that stopped working in Windows.