### PR TITLE
Fixup `destroyTriangleBatch` batch type

### DIFF
--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -1090,7 +1090,7 @@ pub const DebugRenderer = if (!debug_renderer_enabled) extern struct {} else ext
             /// value that was passed to `DebugRenderer.createTriangleBatch`.
             destroyTriangleBatch: *const fn (
                 self: *T,
-                batch: *TriangleBatch,
+                batch: *anyopaque,
             ) callconv(.c) void,
             drawGeometry: *const fn (
                 self: *T,


### PR DESCRIPTION
This commit was intended to be part of https://github.com/zig-gamedev/zphysics/pull/12