### PR TITLE
Moved out castRay arg struct from argument to the owner struct.

### DIFF
--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -2219,14 +2219,15 @@ pub const BodyInterface = opaque {
 //
 //--------------------------------------------------------------------------------------------------
 pub const NarrowPhaseQuery = opaque {
+    pub const CastRayArgs = struct {
+        broad_phase_layer_filter: ?*const BroadPhaseLayerFilter = null,
+        object_layer_filter: ?*const ObjectLayerFilter = null,
+        body_filter: ?*const BodyFilter = null,
+    };
     pub fn castRay(
         query: *const NarrowPhaseQuery,
         ray: RRayCast,
-        args: struct {
-            broad_phase_layer_filter: ?*const BroadPhaseLayerFilter = null,
-            object_layer_filter: ?*const ObjectLayerFilter = null,
-            body_filter: ?*const BodyFilter = null,
-        },
+        args: CastRayArgs,
     ) struct { has_hit: bool, hit: RayCastResult } {
         var hit: RayCastResult = .{};
         const has_hit = c.JPC_NarrowPhaseQuery_CastRay(


### PR DESCRIPTION
This makes a bit nicer to use, previously this was needed: 
<img width="960" height="618" alt="image" src="https://github.com/user-attachments/assets/aca18ef2-98f6-4f73-a3f2-44a9c93cbe3d" />


Und nau: 

<img width="968" height="528" alt="image" src="https://github.com/user-attachments/assets/6cbfcb37-b900-4f83-a76e-ab1f76e73dcc" />
