### PR TITLE
Update getBodiesUnsafe() to return a slice of size getMaxBodies()

### DIFF
--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -1552,7 +1552,7 @@ pub const PhysicsSystem = opaque {
     /// NOTE: Advanced. This function is *not* protected by a lock, use with care!
     pub fn getBodiesMutUnsafe(physics_system: *PhysicsSystem) []const *Body {
         const ptr = c.JPC_PhysicsSystem_GetBodiesUnsafe(@as(*c.JPC_PhysicsSystem, @ptrCast(physics_system)));
-        return @as([*]const *Body, @ptrCast(ptr))[0..physics_system.getNumBodies()];
+        return @as([*]const *Body, @ptrCast(ptr))[0..physics_system.getMaxBodies()];
     }
 };
 //--------------------------------------------------------------------------------------------------
@@ -4554,7 +4554,7 @@ test "zphysics.body.getBodiesUnsafe_after_destroy" {
     
     try expect(physics_system.getNumBodies() == 2);
 
-    const all_bodies = physics_system.getBodiesUnsafe();
+    const all_bodies = physics_system.getBodiesMutUnsafe();
 
     //following should not throw panic
     //zig does not have panic handler for unit tests so best we can do is test happy path or crash program

--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -1547,7 +1547,7 @@ pub const PhysicsSystem = opaque {
         const ptr = c.JPC_PhysicsSystem_GetBodiesUnsafe(
             @as(*c.JPC_PhysicsSystem, @ptrFromInt(@intFromPtr(physics_system))),
         );
-        return @as([*]const *const Body, @ptrCast(ptr))[0..physics_system.getNumBodies()];
+        return @as([*]const *const Body, @ptrCast(ptr))[0..physics_system.getMaxBodies()];
     }
     /// NOTE: Advanced. This function is *not* protected by a lock, use with care!
     pub fn getBodiesMutUnsafe(physics_system: *PhysicsSystem) []const *Body {

--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -4516,8 +4516,53 @@ test "zphysics.body.basic" {
     try expect(physics_system.getNumActiveBodies() == 0);
 }
 
-test "zphysics.body.motion" {
+test "zphysics.body.getBodiesUnsafe_after_destroy" {
     try init(std.testing.allocator, .{});
+    defer deinit();
+
+    const physics_system = try PhysicsSystem.create(
+        @as(*const BroadPhaseLayerInterface, @ptrCast(&test_cb1.MyBroadphaseLayerInterface.init())),
+        @as(*const ObjectVsBroadPhaseLayerFilter, @ptrCast(&test_cb1.MyObjectVsBroadPhaseLayerFilter{})),
+        @as(*const ObjectLayerPairFilter, @ptrCast(&test_cb1.MyObjectLayerPairFilter{})),
+        .{ .max_bodies = 1024, .num_body_mutexes = 0, .max_body_pairs = 1024, .max_contact_constraints = 1024 },
+    );
+    defer physics_system.destroy();
+
+    const body_interface = physics_system.getBodyInterfaceMut();
+
+    const shape_settings = try BoxShapeSettings.create(.{ 1.0, 1.0, 1.0 });
+    defer shape_settings.asShapeSettings().release();
+    const shape = try shape_settings.asShapeSettings().createShape();
+    defer shape.release();
+
+    const settings = BodyCreationSettings{
+        .position = .{ 0, 0, 0, 1 },
+        .rotation = .{ 0, 0, 0, 1 },
+        .shape = shape,
+        .motion_type = .static,
+        .object_layer = test_cb1.object_layers.non_moving,
+    };
+
+    const b0 = try body_interface.createAndAddBody(settings, .activate);
+    const b1 = try body_interface.createAndAddBody(settings, .activate);
+    const b2 = try body_interface.createAndAddBody(settings, .activate);
+
+    _ = b0; //just to rid of compiler error
+
+    body_interface.removeBody(b1);
+    body_interface.destroyBody(b1);
+    
+    try expect(physics_system.getNumBodies() == 2);
+
+    const all_bodies = physics_system.getBodiesUnsafe();
+
+    //following should not throw panic
+    //zig does not have panic handler for unit tests so best we can do is test happy path or crash program
+    _ = tryGetBody(all_bodies, b2);
+}
+
+test "zphysics.body.motion" {
+    try init(std.testing.allocator, .{});   
     defer deinit();
 
     const my_broad_phase_layer_interface = test_cb1.MyBroadphaseLayerInterface.init();

--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -4556,7 +4556,7 @@ test "zphysics.body.getBodiesUnsafe_after_destroy" {
     const b1 = try body_interface.createAndAddBody(settings, .activate);
     const b2 = try body_interface.createAndAddBody(settings, .activate);
 
-    _ = b0; //just to rid of compiler error
+    _ = b0; // silence unused variable warning for testing
 
     body_interface.removeBody(b1);
     body_interface.destroyBody(b1);

--- a/src/zphysics.zig
+++ b/src/zphysics.zig
@@ -4520,11 +4520,20 @@ test "zphysics.body.getBodiesUnsafe_after_destroy" {
     try init(std.testing.allocator, .{});
     defer deinit();
 
+    const my_broad_phase_layer_interface = test_cb1.MyBroadphaseLayerInterface.init();
+    const my_broad_phase_should_collide = test_cb1.MyObjectVsBroadPhaseLayerFilter{};
+    const my_object_should_collide = test_cb1.MyObjectLayerPairFilter{};
+
     const physics_system = try PhysicsSystem.create(
-        @as(*const BroadPhaseLayerInterface, @ptrCast(&test_cb1.MyBroadphaseLayerInterface.init())),
-        @as(*const ObjectVsBroadPhaseLayerFilter, @ptrCast(&test_cb1.MyObjectVsBroadPhaseLayerFilter{})),
-        @as(*const ObjectLayerPairFilter, @ptrCast(&test_cb1.MyObjectLayerPairFilter{})),
-        .{ .max_bodies = 1024, .num_body_mutexes = 0, .max_body_pairs = 1024, .max_contact_constraints = 1024 },
+        @as(*const BroadPhaseLayerInterface, @ptrCast(&my_broad_phase_layer_interface)),
+        @as(*const ObjectVsBroadPhaseLayerFilter, @ptrCast(&my_broad_phase_should_collide)),
+        @as(*const ObjectLayerPairFilter, @ptrCast(&my_object_should_collide)),
+        .{ 
+            .max_bodies = 1024,
+            .num_body_mutexes = 0, 
+            .max_body_pairs = 1024, 
+            .max_contact_constraints = 1024 
+        },
     );
     defer physics_system.destroy();
 


### PR DESCRIPTION
Currently getBodiesUnsafe() returns a slice of size getNumBodies() but getBodiesUnsafe() actually returns a pointer to slice of size max_bodies. 

The issue comes when you delete bodies from the middle and try to access bodies of higher index

getBodiesUnsafe does not reorganize the elements before giving a slice so you can get an out of bounds error

example of the issue is:

let bodies be
[b0, b1, b2] 

if you delete b1 jolt physics updates bodies to
[b0, invalid, b2]

but if you call getBodiesUnsafe you only get
[b0, invalid]

so if you do tryGetBody( all_bodies, b2) then it will look for b2 at index 2 which is out of bounds 